### PR TITLE
Fix get iap projects, database sql, validateIAP endpoint

### DIFF
--- a/Database/iapProxy.js
+++ b/Database/iapProxy.js
@@ -23,25 +23,40 @@ const pool = new Pool({
     port: dbConfig.port,
 });
 
-function fetchProjects(sessionID, callback) {
+//Original -- leaving commented just in case it is useful in the future
+// function fetchProjects(sessionID, callback) {
+//     logCtx.fn = 'fetchProjects';
+//     dbUtils.makeQueryWithParams(pool, "select project_id, session_id, title, abstract from projects where session_id = $1", [sessionID], callback, (error, res) => {
+//         if (error) {
+//             logError(error, logCtx);
+//             callback(error, null);
+//         } else {
+//             log("Got response from DB - rowCount: " + res.rowCount, logCtx);
+//             var result = res.rows; //returns array of json objects
+//             async.forEachLimit(result, 1, (iapProject, cb) => {
+//                 showroomDB.postToShowroomProjects(iapProject, (error) => {
+//                     if (error) {
+//                         logError(error.toString(), logCtx);
+//                     }
+//                     cb(error);
+//                 });
+//             }, (error) => {
+//                 callback(error); //null if no error
+//             });
+//         }
+//     });
+// }
+
+function fetchProjects(callback) {
     logCtx.fn = 'fetchProjects';
-    dbUtils.makeQueryWithParams(pool, "select project_id, session_id, title, abstract from projects where session_id = $1", [sessionID], callback, (error, res) => {
+    dbUtils.makeQuery(pool, "select project_id, title, abstract from projects where session_id = (select year_id as session_id from iap_session where start_date = (select max(start_date) from iap_session))", callback, (error, res) => {
         if (error) {
             logError(error, logCtx);
             callback(error, null);
         } else {
             log("Got response from DB - rowCount: " + res.rowCount, logCtx);
             var result = res.rows; //returns array of json objects
-            async.forEachLimit(result, 1, (iapProject, cb) => {
-                showroomDB.postToShowroomProjects(iapProject, (error) => {
-                    if (error) {
-                        logError(error.toString(), logCtx);
-                    }
-                    cb(error);
-                });
-            }, (error) => {
-                callback(error); //null if no error
-            });
+            callback(error, result); //null if no error
         }
     });
 }

--- a/Database/showroomProxy.js
+++ b/Database/showroomProxy.js
@@ -539,6 +539,7 @@ function getEventByID (eventID, callback) {
     dbUtils.makeQueryWithParams(pool, query, [eventID], callback, queryCb);
 }
 
+//Not used anymore, project information is being pulled directly from IAP's database. There is an equivalent function in iapProxy.js
 function getQnARoomInfo (projectID, callback) {
     logCtx.fn = 'getQnARoomInfo';
     var query = "select proj.iapproject_title, proj.iapproject_abstract, u.first_name, u.last_name, u.user_role, sr.ispm, sr.grad_date from users u left join student_researchers sr on u.userid = sr.userid left join participates p on u.userid = p.userid left join projects proj on p.projectid = proj.projectid where proj.projectid = $1"; 

--- a/Database/showroomProxy.js
+++ b/Database/showroomProxy.js
@@ -317,12 +317,11 @@ function comparePasswords (email, plaintextPassword, callback) {
         function (callback) {
             //Check if user is admin (and add to result along with user ID)
             //Login should also check for other roles 
-            isUserAdmin(result.userID, (error, adminID) => { //TODO: test
+            isUserAdmin(result.userID, (error, adminID) => {
                 if (error) {
                     logError(error, logCtx);
                     callback(error);
                 } else {
-                    // result.admin = isAdmin; //set as either true or false //TODO delete
                     result.admin = adminID; //If it's null, not admin
                     callback(null);
                 }
@@ -727,7 +726,6 @@ function getInPersonStats (callback) {
 
 function getUserInfo (userID, callback) {
     logCtx.fn = 'getUserInfo';
-    // var query = "select first_name, last_name, email, user_role, gender, verifiedemail, department, grad_date, ispm, company_name, adminid, projectid from users as u left join student_researchers as sr on u.userid = sr.userid left join advisors as a on u.userid = a.userid left join admins as adm on u.userid = adm.userid left join participates as p on u.userid = p.userid left join company_representatives as cr on u.userid = cr.userid where u.userid = $1";
     var query = "select first_name, last_name, email, user_role, gender, verifiedemail, department, grad_date, ispm, company_name, adminid, iapprojectid as projectid from users as u left join student_researchers as sr on u.userid = sr.userid left join advisors as a on u.userid = a.userid left join admins as adm on u.userid = adm.userid left join participates as p on u.userid = p.userid left join company_representatives as cr on u.userid = cr.userid where u.userid = $1";
     var queryCb = (error, res) => { 
         if (error) {
@@ -874,7 +872,6 @@ function postAnnouncements (adminID, message, date, callback) {
 
 function getRoleAndName (userID, callback) {
     logCtx.fn = 'getRoleAndName';
-    // var query = "select users.user_role, users.first_name, users.last_name, p.projectid from users left join participates as p on users.userid = p.userid where users.userid = $1"; 
     var query = "select users.user_role, users.first_name, users.last_name, p.iapprojectid as projectid from users left join participates as p on users.userid = p.userid where users.userid = $1"; 
     var queryCb = (error, res) => { 
         if (error) {
@@ -902,7 +899,6 @@ function getRoleAndName (userID, callback) {
 
 function getAllMembersFromAllProjects(callback){
     logCtx.fn = 'getAllMembersFromAllProjects';
-    // var query = "SELECT users.userid, users.user_role, users.first_name, users.last_name, r.projectid, r.iapproject_title, sr.validatedmember, a.validatedmember as validatedAdvisor from users inner join participates p on users.userid = p.userid inner join projects r on p.projectid = r.projectid left outer join student_researchers sr on p.userid = sr.userid left outer join advisors a on p.userid = a.userid group by r.projectid, users.userid, sr.validatedmember, a.validatedmember;";
     var query = "SELECT users.userid, users.user_role, users.first_name, users.last_name, p.iapprojectid as projectid, sr.validatedmember, a.validatedmember as validatedAdvisor from users inner join participates p on users.userid = p.userid left outer join student_researchers sr on p.userid = sr.userid left outer join advisors a on p.userid = a.userid group by p.iapprojectid, users.userid, sr.validatedmember, a.validatedmember;";
     var queryCb = (error, res) => { 
         if (error) {
@@ -946,9 +942,8 @@ function validateResearchMember(userID, user_role, callback){
 
 
 
-function getStudentProject (userID, projectID, callback) { //TODO: test
+function getStudentProject (userID, projectID, callback) {
     logCtx.fn = 'getStudentProject';
-    // var query = "select userid, projectid from participates where userid = $1 and projectid = $2"; 
     var query = "select userid, iapprojectid as projectid from participates where userid = $1 and iapprojectid = $2"; 
     var queryCb = (error, res) => { 
         if (error) {

--- a/Database/showroomProxy.js
+++ b/Database/showroomProxy.js
@@ -197,7 +197,8 @@ function associateProjectsWithUser (userID, projectIDList, callback) {
         //Insert each project ID into DB
         async.forEachLimit(projectIDList, MAX_ASYNC, (projectID, cb) => {
             var values = [userID, projectID];
-            dbUtils.makeQueryWithParams(pool,"insert into participates (userid, projectid) values ($1, $2)", values, cb, (error, res) => {
+            // dbUtils.makeQueryWithParams(pool,"insert into participates (userid, projectid) values ($1, $2)", values, cb, (error, res) => {
+            dbUtils.makeQueryWithParams(pool,"insert into participates (userid, iapprojectid) values ($1, $2)", values, cb, (error, res) => {
                 if (error) {
                     logError(error, logCtx);
                 } else {
@@ -729,7 +730,8 @@ function getInPersonStats (callback) {
 
 function getUserInfo (userID, callback) {
     logCtx.fn = 'getUserInfo';
-    var query = "select first_name, last_name, email, user_role, gender, verifiedemail, department, grad_date, ispm, company_name, adminid, projectid from users as u left join student_researchers as sr on u.userid = sr.userid left join advisors as a on u.userid = a.userid left join admins as adm on u.userid = adm.userid left join participates as p on u.userid = p.userid left join company_representatives as cr on u.userid = cr.userid where u.userid = $1";
+    // var query = "select first_name, last_name, email, user_role, gender, verifiedemail, department, grad_date, ispm, company_name, adminid, projectid from users as u left join student_researchers as sr on u.userid = sr.userid left join advisors as a on u.userid = a.userid left join admins as adm on u.userid = adm.userid left join participates as p on u.userid = p.userid left join company_representatives as cr on u.userid = cr.userid where u.userid = $1";
+    var query = "select first_name, last_name, email, user_role, gender, verifiedemail, department, grad_date, ispm, company_name, adminid, iapprojectid as projectid from users as u left join student_researchers as sr on u.userid = sr.userid left join advisors as a on u.userid = a.userid left join admins as adm on u.userid = adm.userid left join participates as p on u.userid = p.userid left join company_representatives as cr on u.userid = cr.userid where u.userid = $1";
     var queryCb = (error, res) => { 
         if (error) {
             logError(error, logCtx);
@@ -875,7 +877,8 @@ function postAnnouncements (adminID, message, date, callback) {
 
 function getRoleAndName (userID, callback) {
     logCtx.fn = 'getRoleAndName';
-    var query = "select users.user_role, users.first_name, users.last_name, p.projectid from users left join participates as p on users.userid = p.userid where users.userid = $1"; 
+    // var query = "select users.user_role, users.first_name, users.last_name, p.projectid from users left join participates as p on users.userid = p.userid where users.userid = $1"; 
+    var query = "select users.user_role, users.first_name, users.last_name, p.iapprojectid as projectid from users left join participates as p on users.userid = p.userid where users.userid = $1"; 
     var queryCb = (error, res) => { 
         if (error) {
             logError(error, logCtx);
@@ -902,7 +905,8 @@ function getRoleAndName (userID, callback) {
 
 function getAllMembersFromAllProjects(callback){
     logCtx.fn = 'getAllMembersFromAllProjects';
-    var query = "SELECT users.userid, users.user_role, users.first_name, users.last_name, r.projectid, r.iapproject_title, sr.validatedmember, a.validatedmember as validatedAdvisor from users inner join participates p on users.userid = p.userid inner join projects r on p.projectid = r.projectid left outer join student_researchers sr on p.userid = sr.userid left outer join advisors a on p.userid = a.userid group by r.projectid, users.userid, sr.validatedmember, a.validatedmember;";
+    // var query = "SELECT users.userid, users.user_role, users.first_name, users.last_name, r.projectid, r.iapproject_title, sr.validatedmember, a.validatedmember as validatedAdvisor from users inner join participates p on users.userid = p.userid inner join projects r on p.projectid = r.projectid left outer join student_researchers sr on p.userid = sr.userid left outer join advisors a on p.userid = a.userid group by r.projectid, users.userid, sr.validatedmember, a.validatedmember;";
+    var query = "SELECT users.userid, users.user_role, users.first_name, users.last_name, p.iapprojectid as projectid, sr.validatedmember, a.validatedmember as validatedAdvisor from users inner join participates p on users.userid = p.userid left outer join student_researchers sr on p.userid = sr.userid left outer join advisors a on p.userid = a.userid group by p.iapprojectid, users.userid, sr.validatedmember, a.validatedmember;";
     var queryCb = (error, res) => { 
         if (error) {
             logError(error, logCtx);
@@ -947,7 +951,8 @@ function validateResearchMember(userID, user_role, callback){
 
 function getStudentProject (userID, projectID, callback) { //TODO: test
     logCtx.fn = 'getStudentProject';
-    var query = "select userid, projectid from participates where userid = $1 and projectid = $2"; 
+    // var query = "select userid, projectid from participates where userid = $1 and projectid = $2"; 
+    var query = "select userid, iapprojectid as projectid from participates where userid = $1 and iapprojectid = $2"; 
     var queryCb = (error, res) => { 
         if (error) {
             logError(error, logCtx);

--- a/Database/showroomProxy.js
+++ b/Database/showroomProxy.js
@@ -540,25 +540,25 @@ function getEventByID (eventID, callback) {
 }
 
 //Not used anymore, project information is being pulled directly from IAP's database. There is an equivalent function in iapProxy.js
-function getQnARoomInfo (projectID, callback) {
-    logCtx.fn = 'getQnARoomInfo';
-    var query = "select proj.iapproject_title, proj.iapproject_abstract, u.first_name, u.last_name, u.user_role, sr.ispm, sr.grad_date from users u left join student_researchers sr on u.userid = sr.userid left join participates p on u.userid = p.userid left join projects proj on p.projectid = proj.projectid where proj.projectid = $1"; 
-    var queryCb = (error, res) => { 
-        if (error) {
-            logError(error, logCtx);
-            callback(error, null);
-        } else {
-            log("Got response from DB - rowCount: " + res.rowCount, logCtx);
-            if (res.rowCount == 0) {
-                callback(null, null); //No info found, send null result to provoke 404 error
-            } else {
-                var result = res.rows; //returns counts for users
-                callback(null, result);
-            }
-        }
-    };
-    dbUtils.makeQueryWithParams(pool, query, [projectID], callback, queryCb);
-}
+// function getQnARoomInfo (projectID, callback) {
+//     logCtx.fn = 'getQnARoomInfo';
+//     var query = "select proj.iapproject_title, proj.iapproject_abstract, u.first_name, u.last_name, u.user_role, sr.ispm, sr.grad_date from users u left join student_researchers sr on u.userid = sr.userid left join participates p on u.userid = p.userid left join projects proj on p.projectid = proj.projectid where proj.projectid = $1"; 
+//     var queryCb = (error, res) => { 
+//         if (error) {
+//             logError(error, logCtx);
+//             callback(error, null);
+//         } else {
+//             log("Got response from DB - rowCount: " + res.rowCount, logCtx);
+//             if (res.rowCount == 0) {
+//                 callback(null, null); //No info found, send null result to provoke 404 error
+//             } else {
+//                 var result = res.rows; //returns counts for users
+//                 callback(null, result);
+//             }
+//         }
+//     };
+//     dbUtils.makeQueryWithParams(pool, query, [projectID], callback, queryCb);
+// }
 
 function getIAPPIDFromShowroomPID (projectID, callback) {
     logCtx.fn = 'getIAPPIDFromShowroomPID';
@@ -1035,7 +1035,7 @@ module.exports = {
     fetchUserIDsAndRoles: fetchUserIDsAndRoles,
     getAllMembersFromAllProjects: getAllMembersFromAllProjects,
     validateResearchMember: validateResearchMember,
-    getQnARoomInfo: getQnARoomInfo,
+    // getQnARoomInfo: getQnARoomInfo, //Not used anymore
     getName: getName,
     getLiveStats: getLiveStats,
     getInPersonStats: getInPersonStats,

--- a/Database/showroomProxy.js
+++ b/Database/showroomProxy.js
@@ -196,9 +196,8 @@ function associateProjectsWithUser (userID, projectIDList, callback) {
     } else {
         //Insert each project ID into DB
         async.forEachLimit(projectIDList, MAX_ASYNC, (projectID, cb) => {
-            var values = [userID, projectID];
-            // dbUtils.makeQueryWithParams(pool,"insert into participates (userid, projectid) values ($1, $2)", values, cb, (error, res) => {
-            dbUtils.makeQueryWithParams(pool,"insert into participates (userid, iapprojectid) values ($1, $2)", values, cb, (error, res) => {
+            var values = [userID, projectID, projectID];
+            dbUtils.makeQueryWithParams(pool,"insert into participates (userid, projectid, iapprojectid) values ($1, $2, $3)", values, cb, (error, res) => {
                 if (error) {
                     logError(error, logCtx);
                 } else {
@@ -376,10 +375,8 @@ function isUserAdmin (userID, callback) {
         } else {
             log("Got response from DB - rowCount: " + res.rowCount, logCtx);
             if (res.rows.length == 0 ) {
-                // callback(null, false); //TODO: delete
                 callback(null, null);
             } else {
-                // callback(null, true); //Success //TODO: delete
                 callback(null, res.rows[0].adminid); //Success
             }
         }

--- a/Endpoints/ShowroomEndpoints.js
+++ b/Endpoints/ShowroomEndpoints.js
@@ -48,18 +48,13 @@ showroomRouter.get(getAllUsers, auth.authenticate, showroomHandler.getAllUsers);
 //Events 
 showroomRouter.get(getRoomStatus, auth.authenticate, showroomHandler.getRoomStatus);
 showroomRouter.get(getQnARoomInfo, auth.authenticate, showroomHandler.getQnARoomInfo); 
-showroomRouter.get(getIAPValidation, showroomHandler.validateIAPUser); 
+showroomRouter.post(getIAPValidation, showroomHandler.validateIAPUser); 
 showroomRouter.get(scheduleEvents, auth.authenticate, showroomHandler.getScheduleEvents); 
 showroomRouter.post(scheduleEvents, auth.authorizeAdmin, showroomHandler.postScheduleEvents); 
 showroomRouter.get(scheduleEventsID, auth.authorizeAdmin, showroomHandler.getScheduleEventByID);
 showroomRouter.put(updateBatchEvents, auth.authorizeAdmin, showroomHandler.updateBatchEvents);
 showroomRouter.put(scheduleEventsID, auth.authorizeAdmin, showroomHandler.updateScheduleEvent);
 showroomRouter.delete(scheduleEventsID, auth.authorizeAdmin, showroomHandler.deleteScheduleEvent);
-
-// Server Side Events
-// showroomRouter.get(sseConnect, auth.authenticate, showroomHandler.sseConnect);
-// showroomRouter.get(serverSideSent, auth.authenticate, showroomHandler.getServerSideUpcomingEvents);
-// showroomRouter.get(serverSideSent, auth.authenticate, showroomHandler.getServerSideProgressBar);
 
 //IAP
 showroomRouter.get(getIAPProjects, showroomHandler.getProjects);

--- a/Handlers/ShowroomHandlers.js
+++ b/Handlers/ShowroomHandlers.js
@@ -1134,7 +1134,7 @@ function getProjects (req, res, next) {
         // },
         function (callback) {
             //Fetch projects from IAP
-            showroomDB.fetchProjects(finalSessionID, (error, iapProjects) => { //result is array of objs with project info
+            iapDB.fetchProjects((error, iapProjects) => { //result is array of objs with project info
                 if (error) {
                     errorStatus = 500;
                     errorMsg = error.toString();

--- a/Handlers/ShowroomHandlers.js
+++ b/Handlers/ShowroomHandlers.js
@@ -993,50 +993,48 @@ function getProjects (req, res, next) {
                 callback(error);
             });
         },
+        // function (callback) {
+        //     sessionID = req.query.session_id;
+        //     updateProjects = req.query.update;
+        //     if (sessionID == undefined) {
+        //         //Fetch session being used in Showroom's projects table
+        //         showroomDB.fetchShowroomSession((error, showroomSession) => {
+        //             if (error) {
+        //                 logError(error, logCtx);
+        //                 errorMsg = error.toString();
+        //                 errorStatus = 500;
+        //                 callback(error);
+        //             } else {
+        //                 if (showroomSession == null) { //No projects were found
+        //                     sessionID = 1; //Set as incorrect session on purpose to trigger update
+        //                 } else {
+        //                     log("Response data: " + JSON.stringify(showroomSession), logCtx);
+        //                     sessionID = showroomSession;
+        //                 }
+        //                 callback(null);
+        //             }
+        //         });
+        //     } else {
+        //         callback(null); //Session ID was provided, skip
+        //     }
+        // },
+        // function (callback) {
+        //     if (updateProjects != undefined && updateProjects == "true") {
+        //         //Fetch the current session used in Showroom's projects
+        //         //Update table with projects from given session if they don't match
+        //         checkSessionAndUpdate(sessionID, (error, latestSession) => {
+        //             if (error) {
+        //                 logError(error, logCtx);
+        //                 errorMsg = error.toString();
+        //                 errorStatus = 500;
+        //             }
+        //             callback(error, latestSession); //Null if no error
+        //         });
+        //     } else {
+        //         callback(null, null); //Skip
+        //     }
+        // },
         function (callback) {
-            sessionID = req.query.session_id;
-            updateProjects = req.query.update;
-            if (sessionID == undefined) {
-                //Fetch session being used in Showroom's projects table
-                showroomDB.fetchShowroomSession((error, showroomSession) => {
-                    if (error) {
-                        logError(error, logCtx);
-                        errorMsg = error.toString();
-                        errorStatus = 500;
-                        callback(error);
-                    } else {
-                        if (showroomSession == null) { //No projects were found
-                            sessionID = 1; //Set as incorrect session on purpose to trigger update
-                        } else {
-                            log("Response data: " + JSON.stringify(showroomSession), logCtx);
-                            sessionID = showroomSession;
-                        }
-                        callback(null);
-                    }
-                });
-            } else {
-                callback(null); //Session ID was provided, skip
-            }
-        },
-        function (callback) {
-            if (updateProjects != undefined && updateProjects == "true") {
-                //Fetch the current session used in Showroom's projects
-                //Update table with projects from given session if they don't match
-                checkSessionAndUpdate(sessionID, (error, latestSession) => {
-                    if (error) {
-                        logError(error, logCtx);
-                        errorMsg = error.toString();
-                        errorStatus = 500;
-                    }
-                    callback(error, latestSession); //Null if no error
-                });
-            } else {
-                callback(null, null); //Skip
-            }
-        },
-        function (latestSession, callback) {
-            logCtx.fn = "getProjects";
-            var finalSessionID = updateProjects != undefined && updateProjects == "true" ? latestSession : sessionID;
             //Fetch projects from IAP
             showroomDB.fetchProjects(finalSessionID, (error, iapProjects) => { //result is array of objs with project info
                 if (error) {

--- a/Handlers/ShowroomHandlers.js
+++ b/Handlers/ShowroomHandlers.js
@@ -383,29 +383,10 @@ function getQnARoomInfo (req, res, next) {
         },
         function (callback) {
             projectID = req.query.meeting_id;
-            performBBBOps = req.query.bbb; //Indicate whether or not to only bring room info or also do BBB operations
-
-            //Fetch IAP's project ID based on the given project ID from Showroom's table 
-            showroomDB.getIAPPIDFromShowroomPID(projectID, (error, iapPID) => {
-                if (error) {
-                    errorStatus = 500;
-                    errorMsg = error.toString();
-                    logError(error, logCtx);
-                    callback(error, null);
-                } else if (iapPID == undefined || iapPID == null) {
-                    errorStatus = 404;
-                    errorMsg = "No IAP project id found for given ID.";
-                    logError(errorMsg, logCtx);
-                    callback(new Error(errorMsg), null);
-                } else {
-                    log("Response data: " + JSON.stringify(iapPID), logCtx);
-                    callback(null, iapPID);
-                }
-            });
-        },
-        function (iapPID, callback) {
+            //Indicate whether or not to only bring room info or also do BBB operations
+            performBBBOps = req.query.bbb; 
             //Fetch title, abstract, and users associated with project 
-            iapDB.fetchQnARoomInfo(iapPID, (error, result) => {
+            iapDB.fetchQnARoomInfo(projectID, (error, result) => {
                 if (error) {
                     errorStatus = 500;
                     errorMsg = error.toString();
@@ -535,7 +516,7 @@ function getQnARoomInfo (req, res, next) {
 function validateIAPUser (req, res, next) {
     logCtx.fn = 'validateIAPUser';
     var isValid = true;
-    var iDSet = new Set();
+    var iDSet;
     var errorStatus, errorMsg, givenProjectIDs;
     async.waterfall([
         function (callback) {
@@ -558,38 +539,17 @@ function validateIAPUser (req, res, next) {
                     errorStatus = 500;
                     errorMsg = error.toString();
                     logError(error, logCtx);
-                    callback(error, null);
+                    callback(error); 
                 } else if (result == undefined || result == null) {
-                    errorStatus = 404;
                     errorMsg = "No IAP project IDs found associated with given email.";
                     logError(errorMsg, logCtx);
-                    callback(new Error(errorMsg), null);
+                    iDSet = new Set();
+                    callback(null);
                 } else {
                     log("Response data: " + JSON.stringify(result), logCtx);
-                    callback(null, result);
+                    iDSet = new Set(result);
+                    callback(null);
                 }
-            });
-        },
-        function (iapProjectIDs, callback) {
-            async.forEachLimit(iapProjectIDs, 1, (iapPID, cb) => {
-                //Fetch Showroom's project ID based on the given project ID from IAP
-                showroomDB.getShowroomPIDFromIAPPID(iapPID, (error, showroomID) => {
-                    if (error) {
-                        errorStatus = 500;
-                        errorMsg = error.toString();
-                        logError(error, logCtx);
-                        cb(error);
-                    } else if (showroomID != undefined && showroomID != null) {
-                        log("Response data: " + JSON.stringify(showroomID), logCtx);
-                        iDSet.add(showroomID);
-                        cb(null);
-                    } else {
-                        log("No Showroom project ID found for given IAP project ID: " + iapPID, logCtx);
-                        cb(null);
-                    }
-                });
-            }, (error) => {
-                callback(error); //null if no error
             });
         },
         function (callback) {
@@ -988,10 +948,6 @@ function updateBatchEvents (req, res, next) {
     });
 }
 
-
-
-
-
 function deleteScheduleEvent (req, res, next) {
     logCtx.fn = 'deleteScheduleEvent';
     var errorStatus, errorMsg;
@@ -1091,47 +1047,6 @@ function getProjects (req, res, next) {
                 callback(error);
             });
         },
-        // function (callback) {
-        //     sessionID = req.query.session_id;
-        //     updateProjects = req.query.update;
-        //     if (sessionID == undefined) {
-        //         //Fetch session being used in Showroom's projects table
-        //         showroomDB.fetchShowroomSession((error, showroomSession) => {
-        //             if (error) {
-        //                 logError(error, logCtx);
-        //                 errorMsg = error.toString();
-        //                 errorStatus = 500;
-        //                 callback(error);
-        //             } else {
-        //                 if (showroomSession == null) { //No projects were found
-        //                     sessionID = 1; //Set as incorrect session on purpose to trigger update
-        //                 } else {
-        //                     log("Response data: " + JSON.stringify(showroomSession), logCtx);
-        //                     sessionID = showroomSession;
-        //                 }
-        //                 callback(null);
-        //             }
-        //         });
-        //     } else {
-        //         callback(null); //Session ID was provided, skip
-        //     }
-        // },
-        // function (callback) {
-        //     if (updateProjects != undefined && updateProjects == "true") {
-        //         //Fetch the current session used in Showroom's projects
-        //         //Update table with projects from given session if they don't match
-        //         checkSessionAndUpdate(sessionID, (error, latestSession) => {
-        //             if (error) {
-        //                 logError(error, logCtx);
-        //                 errorMsg = error.toString();
-        //                 errorStatus = 500;
-        //             }
-        //             callback(error, latestSession); //Null if no error
-        //         });
-        //     } else {
-        //         callback(null, null); //Skip
-        //     }
-        // },
         function (callback) {
             //Fetch projects from IAP
             iapDB.fetchProjects((error, iapProjects) => { //result is array of objs with project info

--- a/Testing/DBTesting.js
+++ b/Testing/DBTesting.js
@@ -18,7 +18,7 @@ let logCtx = {
 
 //run test:
 
-// iapProjectsTest();
+iapProjectsTest();
 // testEventArrayMapping();
 // testCreateEvent();
 // testGetEvents();
@@ -42,7 +42,7 @@ let logCtx = {
 // testFetchProjectsForEmail();
 // testGetShowroomPIDFromIAPPID();
 // testValidateEmailWithUserID();
-testFetchEUUID();
+// testFetchEUUID();
 
 
 //test functions:
@@ -471,11 +471,12 @@ function testEventArrayMapping() {
 function iapProjectsTest () {
     logCtx.fn = 'iapProjectsTest';
     logTest("Test started", logCtx);
-    var session_id = '14';
-    iapDB.fetchProjects(session_id, (error) => {
+    iapDB.fetchProjects((error, result) => {
         if (error) {
             logError(error, logCtx);
         }
+        logTest("Result:", logCtx);
+        console.log(result);
         iapDB.endPool();
         logTest("Test ended", logCtx);
     });

--- a/showroom_database.sql
+++ b/showroom_database.sql
@@ -8,11 +8,11 @@ CREATE TABLE Company_Representatives(representativeid serial primary key, userid
 
 CREATE TABLE Advisors(advisorid serial primary key, userid integer references Users(userid), validatedmember boolean);
 
-CREATE TABLE Projects(projectid serial primary key, IAPprojectid int, IAPsessionid int, IAPproject_title text, IAPproject_abstract text);
+CREATE TABLE Projects(projectid serial primary key, IAPprojectid int, IAPsessionid int, IAPproject_title text, IAPproject_abstract text, isLatest boolean);
 
 CREATE TABLE IAP_Events(meetid serial primary key, adminid integer references Admins(adminid), projectid integer references Projects(projectid), startTime timestamp, duration integer, title text, e_date timestamp, isdeleted boolean);
 
-CREATE TABLE MeetHistory(meethistoryid serial primary key, meetid integer references IAP_Events(meetid), userid integer references Users(userid), jointime timestamp);
+CREATE TABLE MeetHistory(meethistoryid serial primary key, projectid integer references Projects(projectid), userid integer references Users(userid), jointime timestamp);
 
 CREATE TABLE Announcements(announcementid serial primary key, adminid integer references Admins(adminid), a_content text, a_date timestamp);
 
@@ -21,3 +21,15 @@ CREATE TABLE participates(userid integer references Users(userid), projectid int
 CREATE TABLE EmailUUID(emailid serial primary key, userid integer references Users(userid), eUUID text, expiration timestamp);
 
 CREATE TABLE InPerson_Users(uID serial primary key, first_name varchar(60), last_name varchar(60), email varchar(60), gender text, user_role varchar(30), major text, grad_date text, department text, company_name text);
+
+-- Needs to update in production
+CREATE TABLE Conference(cID serial primary key, c_text text, c_date date, isDeleted boolean);
+ALTER TABLE iap_events ADD COLUMN cID INT;
+ALTER TABLE iap_events ADD FOREIGN KEY (cID) REFERENCES Conference(cID);
+ALTER TABLE inperson_users ADD COLUMN live_date DATE;
+ALTER TABLE EmailUUID ADD COLUMN type text;
+
+-- Commands to drop project id fkey constraints in order to use IAP project ids
+ALTER TABLE meethistory DROP CONSTRAINT meethistory_projectid_fkey;
+ALTER TABLE participates DROP CONSTRAINT participates_projectid_fkey;
+ALTER TABLE iap_events DROP CONSTRAINT iap_events_projectid_fkey;


### PR DESCRIPTION
Changes in this PR:
* changes so that the system keeps working as intended but retrieving project information from IAP's database and not Showroom's database
* It also adds sql schema changes for database changes
* updates for the validateIAP endpoint
-- make it post instead of get
-- use iap project ids instead of translating showroom project ids
-- make it not return error when its invalid, simply say its invalid but successful call
